### PR TITLE
Meta yaml

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -12,7 +12,7 @@ configure_requires:
 distribution_type: module
 dynamic_config: 1
 generated_by: 'Module::Install version 1.14'
-license: gplv2
+license: gpl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
   version: 1.4

--- a/META.yml
+++ b/META.yml
@@ -27,6 +27,7 @@ requires:
   Net::DNS::Paranoid: 0
   Scalar::Util: 0
   Time::HiRes: '1.9716'
+  Perl: 5.006
 resources:
   license: http://opensource.org/licenses/gpl-license.php
   repository: https://github.com/bestpractical/lwp-useragent-paranoid.git

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use inc::Module::Install;
 name        'LWP-UserAgent-Paranoid';
 all_from    'lib/LWP/UserAgent/Paranoid.pm';
 readme_from 'lib/LWP/UserAgent/Paranoid.pm';
-license     'gplv2';
+license     'gpl';
 
 repository 'https://github.com/bestpractical/lwp-useragent-paranoid.git';
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,5 +17,7 @@ test_requires 'Test::Requires';
 test_requires 'Test::TCP';
 test_requires 'HTTP::Server::PSGI';
 
+perl_version '5.006';
+
 sign;
 WriteAll;


### PR DESCRIPTION
These very minor changes just exist to pass some of the CPANTS tests.

The Meta spec only accepts 'gpl' as a valid license value, so the trailing version has been removed. Since the specific license version is specified in the README anyway hopefully this won't present any problem.

I've taken 5.6.0 as the minimum perl version as the only place 'perlver' reports a higher minimum is in t/compat/40-slowserver.t (for "use threads"). If you think it should be the higher limit of 5.8.0 just let me know and I'll patch it.

These changes have arisen as part of the [CPAN PR Challenge](http://cpan-prc.org/).
